### PR TITLE
Add company_type when converting to array

### DIFF
--- a/src/Model/Customer/Customer.php
+++ b/src/Model/Customer/Customer.php
@@ -334,6 +334,9 @@ class Customer implements CreatableFromArray
         if (null !== $this->deliveryAddress) {
             $data['delivery_address'] = $this->deliveryAddress->toArray();
         }
+        if (null !== $this->companyType) {
+            $data['company_type'] = $this->companyType;
+        }
 
         return $data;
     }


### PR DESCRIPTION
Add `company_type` to exported array when using `toArray` on a Customer object.